### PR TITLE
#3 - added missing permissions

### DIFF
--- a/app/src/main/java/com/artemkaxboy/android/autoredialce/utils/PermissionHelper.kt
+++ b/app/src/main/java/com/artemkaxboy/android/autoredialce/utils/PermissionHelper.kt
@@ -19,7 +19,10 @@ object PermissionHelper {
                 rawPermissions = listOf(Manifest.permission.READ_CALL_LOG,
                         Manifest.permission.READ_CONTACTS,
                         Manifest.permission.CALL_PHONE,
-                        Manifest.permission.GET_ACCOUNTS)
+                        Manifest.permission.GET_ACCOUNTS,
+                        Manifest.permission.READ_PHONE_STATE,
+                        Manifest.permission.CALL_PHONE,
+                        Manifest.permission.PROCESS_OUTGOING_CALLS)
             }
             return rawPermissions ?: throw AssertionError("Internal error")
         }


### PR DESCRIPTION
There was a bunch of permissions which should be given explicitly to receive broadcasts and make calls. Now prompt appears.