### PR TITLE
#57 - empty values in preferences treats as cancel

### DIFF
--- a/app/src/main/java/com/artemkaxboy/android/autoredialce/ui/preferences/EditNumberDialog.kt
+++ b/app/src/main/java/com/artemkaxboy/android/autoredialce/ui/preferences/EditNumberDialog.kt
@@ -10,9 +10,12 @@ import com.artemkaxboy.android.autoredialce.ext.InputFilterMinMax
 
 class EditNumberDialog : androidx.preference.EditTextPreferenceDialogFragmentCompat() {
 
+    var editText: EditText? = null
+
     override fun onBindDialogView(view: View?) {
         super.onBindDialogView(view)
-        view?.findViewById<EditText>(android.R.id.edit)?.let {
+        editText = view?.findViewById<EditText>(android.R.id.edit)
+        editText?.let {
             setExtraAttrs(it)
 
             it.setOnEditorActionListener { _, actionId, _ ->
@@ -24,6 +27,16 @@ class EditNumberDialog : androidx.preference.EditTextPreferenceDialogFragmentCom
             it.imeOptions = EditorInfo.IME_ACTION_DONE
             it.inputType = InputType.TYPE_CLASS_NUMBER
             it.selectAll()
+        }
+    }
+
+    override fun onDialogClosed(positiveResult: Boolean) {
+        if (positiveResult && editText != null && editText!!.text.isNotEmpty()) {
+            // trim insignificant zeros
+            val value = editText!!.text.toString().toDouble()
+            val string = if (value % 1.0 == 0.0) value.toInt().toString() else value.toString()
+            editText!!.setText(string)
+            super.onDialogClosed(positiveResult)
         }
     }
 

--- a/app/src/main/res/xml/prefx_autoredial.xml
+++ b/app/src/main/res/xml/prefx_autoredial.xml
@@ -27,8 +27,8 @@
       app:dialogTitle="@string/numDialog"
       app:iconSpaceReserved="false"
       app:key="redialing_attempts_count"
-      app:minValue="1"
       app:maxValue="999"
+      app:minValue="1"
       app:title="@string/num"
       app:useSimpleSummaryProvider="true"/>
 
@@ -49,6 +49,8 @@
       app:dialogTitle="@string/pauseRange"
       app:iconSpaceReserved="false"
       app:key="redialing_pause"
+      app:maxValue="86400"
+      app:minValue="0"
       app:title="@string/pause"
       app:useSimpleSummaryProvider="true"/>
 
@@ -69,6 +71,8 @@
       app:dialogTitle="@string/confirmDialog"
       app:iconSpaceReserved="false"
       app:key="minDuration"
+      app:maxValue="9999"
+      app:minValue="0"
       app:title="@string/confirm"
       app:useSimpleSummaryProvider="true"/>
 
@@ -105,6 +109,8 @@
       app:dialogTitle="@string/speaker_delay_title"
       app:iconSpaceReserved="false"
       app:key="speaker_time"
+      app:maxValue="5000"
+      app:minValue="1"
       app:title="@string/speaker_delay"
       app:useSimpleSummaryProvider="true"/>
 

--- a/build.gradle
+++ b/build.gradle
@@ -58,7 +58,7 @@ buildscript {
 
     // Tools versions.
     ext.gradleGoogleVersion = '3.2.0'
-    ext.gradleToolsVersion = '3.4.1'
+    ext.gradleToolsVersion = '3.4.2'
     ext.kotlinVersion = '1.3.41'
 
     // Testing versions.


### PR DESCRIPTION
It seems to be a vicious approach not to close a dialog fragment on empty values, at the same time we cannot treat empty values as 0 because it may not meet allowed range. So the solution of the situation was to treat empty values as dialog cancel.